### PR TITLE
Added SERequestManager.createToken(Map<String, Object> dataMap, String customerSecret, TokenConnectionResult callback)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -81,7 +81,7 @@ One more time, you need:
 ```java
      private void obtainCreateToken(SEProvider selectedProvider, String callbackUrl, String customerSecret) {
          String providerCode = selectedProvider.getCode();
-         String[] scopes = {"accounts", "transactions"};;
+         String[] scopes = {"accounts", "transactions"};
          SERequestManager.getInstance().createToken(providerCode, scopes, callbackUrl, customerSecret,
              new TokenConnectionResult() {
                  @Override
@@ -96,6 +96,30 @@ One more time, you need:
              });
     }
 ```
+or call createToken(...) with custom map of params
+```java
+     private void obtainCreateToken(SEProvider selectedProvider, String callbackUrl, String customerSecret) {
+         HashMap<String, Object> dataMap = new HashMap<>();
+         String providerCode = selectedProvider.getCode();
+         dataMap.put("provider_code", providerCode);
+         String[] scopes = {"accounts", "transactions"};
+         dataMap.put("scopes", scopes);
+         dataMap.put("return_to", "custom return url");
+         SERequestManager.getInstance().createToken(dataMap, customerSecret,
+             new TokenConnectionResult() {
+                 @Override
+                 public void onSuccess(String connectUrl) {
+                     // here is a URL you can use to redirect the user
+                 }
+
+                 @Override
+                 public void onFailure(String errorMessage) {
+                     //process error
+                 }
+             });
+    }
+```
+
 * Using the returned URL, you can let the user import their data. After doing this, you will obtain a `loginSecret`.
 
 ```java   

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.2"
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         applicationId "sdk.saltedge.com.sample"
@@ -20,9 +20,9 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:27.0.2'
-    compile 'com.android.support:design:27.0.2'
-    compile project(':saltedge-library')
-    compile 'com.google.code.gson:gson:2.8.2'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:27.1.0'
+    implementation 'com.android.support:design:27.1.0'
+    implementation project(':saltedge-library')
+    implementation 'com.google.code.gson:gson:2.8.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jan 29 09:58:51 EET 2018
+#Thu Mar 29 16:37:34 EEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/saltedge-library/build.gradle
+++ b/saltedge-library/build.gradle
@@ -2,14 +2,14 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.2"
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.test.InstrumentationTestRunner"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -24,7 +24,6 @@ android {
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/NOTICE'
     }
-
 }
 
 dependencies {
@@ -33,12 +32,16 @@ dependencies {
         maven {
             url 'https://oss.sonatype.org/content/repositories/snapshots/'
         }
-        compile fileTree(dir: 'libs', include: ['*.jar'])
-        compile 'com.squareup.retrofit2:retrofit:2.3.0'
-        compile 'com.squareup.retrofit2:converter-gson:2.3.0'
-        compile 'com.squareup.okhttp3:logging-interceptor:3.9.1'
+        implementation fileTree(dir: 'libs', include: ['*.jar'])
+        implementation 'com.squareup.retrofit2:retrofit:2.3.0'
+        implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
+        implementation 'com.squareup.okhttp3:logging-interceptor:3.9.1'
     }
-    androidTestCompile 'org.hamcrest:hamcrest-core:1.3'
-    androidTestCompile 'org.hamcrest:hamcrest-integration:1.3'
-    androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test:rules:1.0.1'
+    androidTestImplementation 'org.hamcrest:hamcrest-core:1.3'
+    androidTestImplementation 'org.hamcrest:hamcrest-integration:1.3'
+    androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
+    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.9.1'
 }

--- a/saltedge-library/src/androidTest/java/com/saltedge/sdk/connector/TokenConnectorTest.java
+++ b/saltedge-library/src/androidTest/java/com/saltedge/sdk/connector/TokenConnectorTest.java
@@ -1,0 +1,146 @@
+package com.saltedge.sdk.connector;
+
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.saltedge.sdk.SaltEdgeSDK;
+import com.saltedge.sdk.interfaces.TokenConnectionResult;
+import com.saltedge.sdk.network.ApiInterface;
+import com.saltedge.sdk.network.HeaderInterceptor;
+import com.saltedge.sdk.network.SERestClient;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+public class TokenConnectorTest implements TokenConnectionResult {
+
+    @Test
+    public void createTokenTest() throws Exception {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody(successResponse));
+
+        String[] scopes = {"value2", "value3"};
+        new TokenConnector(this).createToken("test_provider_code", scopes, "test_url", "test customer secret");
+        doneSignal.await(5, TimeUnit.SECONDS);
+        RecordedRequest request = mockWebServer.takeRequest();
+
+        Assert.assertFalse(mockRetrofit.baseUrl().toString().isEmpty());
+        assertThat(request.getPath(), equalTo("/api/v4/tokens/create"));
+
+        Assert.assertNull(errorMessage);
+        assertThat(connectUrl, equalTo("test_connect_url"));
+    }
+
+    @Test
+    public void createTokenWithMapDataTest() throws Exception {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody(successResponse));
+
+        HashMap<String, Object> dataMap = new HashMap<>();
+        dataMap.put("provider_code", "test_provider_code");
+        String[] scopes = {"scope1", "scope2"};
+        dataMap.put("scopes", scopes);
+        dataMap.put("return_to", "test_url");
+        new TokenConnector(this).createToken(dataMap, "test customer secret");
+        doneSignal.await(5, TimeUnit.SECONDS);
+        RecordedRequest request = mockWebServer.takeRequest();
+
+        Assert.assertFalse(mockRetrofit.baseUrl().toString().isEmpty());
+        assertThat(request.getPath(), equalTo("/api/v4/tokens/create"));
+
+        Assert.assertNull(errorMessage);
+        assertThat(connectUrl, equalTo("test_connect_url"));
+    }
+
+    @Test
+    public void createTokenTestWithErrorResult() throws Exception {
+        String errorResponse = "{\"error_class\": \"ResourceNotFound\", \"error_message\": \"Resource Not Found\"}";
+        mockWebServer.enqueue(new MockResponse().setResponseCode(404).setBody(errorResponse));
+
+        String[] scopes = {"value2", "value3"};
+        new TokenConnector(this).createToken("test_provider_code", scopes, "test_url", "test customer secret");
+        doneSignal.await(5, TimeUnit.SECONDS);
+        RecordedRequest request = mockWebServer.takeRequest();
+
+        Assert.assertFalse(mockRetrofit.baseUrl().toString().isEmpty());
+        assertThat(request.getPath(), equalTo("/api/v4/tokens/create"));
+        assertThat(errorMessage, equalTo("Resource Not Found"));
+        Assert.assertNull(connectUrl);
+    }
+
+    private CountDownLatch doneSignal;
+    private MockWebServer mockWebServer;
+    private Retrofit mockRetrofit;
+    private String connectUrl;
+    private String errorMessage;
+    private String successResponse = "{\"data\": { \"connect_url\": \"test_connect_url\", \"token\": \"test_token\", \"expires_at\": \"2017-06-13T13:02:06.124Z\"} }";
+
+    @Before
+    public void setUp() throws Exception {
+        SaltEdgeSDK.getInstance().init(InstrumentationRegistry.getTargetContext(), "testClientId", "testAppSecret");
+        connectUrl = null;
+        errorMessage = null;
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        HttpUrl url = mockWebServer.url("/");
+        mockRetrofit = createMockRetrofit(url);
+        SERestClient.getInstance().service = mockRetrofit.create(ApiInterface.class);
+        doneSignal = new CountDownLatch(1);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (mockWebServer != null) mockWebServer.shutdown();
+    }
+
+    private Retrofit createMockRetrofit(HttpUrl url) {
+        return new Retrofit.Builder()
+                .baseUrl(url)
+                .client(createTestClient())
+                .addConverterFactory(GsonConverterFactory.create())
+                .build();
+    }
+
+    private OkHttpClient createTestClient() {
+        return new OkHttpClient.Builder()
+                .addInterceptor(new HeaderInterceptor())
+                .addInterceptor(prepareLoginInterceptor())
+                .build();
+    }
+
+    private HttpLoggingInterceptor prepareLoginInterceptor() {
+        HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor();
+        interceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+        return interceptor;
+    }
+
+    @Override
+    public void onSuccess(String connectUrl) {
+        this.connectUrl = connectUrl;
+        doneSignal.countDown();
+    }
+
+    @Override
+    public void onFailure(String errorMessage) {
+        this.errorMessage = errorMessage;
+        doneSignal.countDown();
+    }
+}

--- a/saltedge-library/src/androidTest/java/com/saltedge/sdk/utils/SEDateToolsTest.java
+++ b/saltedge-library/src/androidTest/java/com/saltedge/sdk/utils/SEDateToolsTest.java
@@ -48,7 +48,7 @@ public class SEDateToolsTest extends TestCase {
     }
 
     @SmallTest
-    public void testParseDateToShortStrin() throws Exception {
+    public void testParseDateToShortString() throws Exception {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.getDefault());
         Date date = sdf.parse("2015-01-23T15:05:13Z");
         assertEquals("2015-01-23", SEDateTools.parseDateToShortString(date));

--- a/saltedge-library/src/main/AndroidManifest.xml
+++ b/saltedge-library/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.saltedge.sdk">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application android:allowBackup="true" android:label="@string/app_name">

--- a/saltedge-library/src/main/java/com/saltedge/sdk/connector/TokenConnector.java
+++ b/saltedge-library/src/main/java/com/saltedge/sdk/connector/TokenConnector.java
@@ -23,10 +23,13 @@ package com.saltedge.sdk.connector;
 
 import com.saltedge.sdk.interfaces.TokenConnectionResult;
 import com.saltedge.sdk.model.request.CreateTokenRequest;
+import com.saltedge.sdk.model.request.MappedRequest;
 import com.saltedge.sdk.model.request.TokenRequest;
 import com.saltedge.sdk.model.response.CreateTokenResponse;
 import com.saltedge.sdk.network.SERestClient;
 import com.saltedge.sdk.utils.SEJsonTools;
+
+import java.util.Map;
 
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -42,6 +45,11 @@ public class TokenConnector implements Callback<CreateTokenResponse> {
 
     public void createToken(String providerCode, String[] scopes, String returnTo, String customerSecret) {
         CreateTokenRequest request = new CreateTokenRequest(new String[0], providerCode, scopes, returnTo);
+        SERestClient.getInstance().service.createToken(customerSecret, request).enqueue(this);
+    }
+
+    public void createToken(Map<String, Object> dataMap, String customerSecret) {
+        MappedRequest request = new MappedRequest(dataMap);
         SERestClient.getInstance().service.createToken(customerSecret, request).enqueue(this);
     }
 

--- a/saltedge-library/src/main/java/com/saltedge/sdk/model/request/MappedRequest.java
+++ b/saltedge-library/src/main/java/com/saltedge/sdk/model/request/MappedRequest.java
@@ -1,0 +1,37 @@
+/*
+Copyright © 2018 Salt Edge. https://saltedge.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package com.saltedge.sdk.model.request;
+
+import com.google.gson.annotations.SerializedName;
+import com.saltedge.sdk.utils.SEConstants;
+
+import java.util.Map;
+
+public class MappedRequest {
+
+    @SerializedName(SEConstants.KEY_DATA)
+    private Map<String, Object> dataMap;
+
+    public MappedRequest(Map<String, Object> dataMap) {
+        this.dataMap = dataMap;
+    }
+}

--- a/saltedge-library/src/main/java/com/saltedge/sdk/network/ApiConstants.java
+++ b/saltedge-library/src/main/java/com/saltedge/sdk/network/ApiConstants.java
@@ -39,7 +39,7 @@ public class ApiConstants {
     static final String ROOT_URL = "https://www.saltedge.com";
     private static final String API_VERSION_PATH = "/api/v4";
     static final String API_CUSTOMERS_PATH = API_VERSION_PATH + "/customers";
-    static final String API_PROVIDERS_PATHL = API_VERSION_PATH + "/providers";
+    static final String API_PROVIDERS_PATH = API_VERSION_PATH + "/providers";
     static final String PER_PAGE = API_VERSION_PATH + "/per";
     private static final String API_TOKENS_PATH = API_VERSION_PATH + "/tokens";
     static final String API_LOGIN_PATH = API_VERSION_PATH + "/login";

--- a/saltedge-library/src/main/java/com/saltedge/sdk/network/ApiInterface.java
+++ b/saltedge-library/src/main/java/com/saltedge/sdk/network/ApiInterface.java
@@ -23,6 +23,7 @@ package com.saltedge.sdk.network;
 
 import com.saltedge.sdk.model.request.CreateCustomerRequest;
 import com.saltedge.sdk.model.request.CreateTokenRequest;
+import com.saltedge.sdk.model.request.MappedRequest;
 import com.saltedge.sdk.model.request.TokenRequest;
 import com.saltedge.sdk.model.response.AccountsResponse;
 import com.saltedge.sdk.model.response.CreateCustomerResponse;
@@ -50,6 +51,10 @@ public interface ApiInterface {
     Call<CreateTokenResponse> createToken(@Header(ApiConstants.KEY_HEADER_CUSTOMER_SECRET) String customerSecret,
                                           @Body CreateTokenRequest body);
 
+    @POST(ApiConstants.API_TOKEN_CREATE_PATH)
+    Call<CreateTokenResponse> createToken(@Header(ApiConstants.KEY_HEADER_CUSTOMER_SECRET) String customerSecret,
+                                          @Body MappedRequest body);
+
     @POST(ApiConstants.API_TOKEN_RECONNECT_PATH)
     Call<CreateTokenResponse> reconnectToken(@Header(ApiConstants.KEY_HEADER_CUSTOMER_SECRET) String customerSecret,
                                              @Header(ApiConstants.KEY_HEADER_LOGIN_SECRET) String loginSecret,
@@ -60,7 +65,7 @@ public interface ApiInterface {
                                            @Header(ApiConstants.KEY_HEADER_LOGIN_SECRET) String loginSecret,
                                            @Body TokenRequest body);
 
-    @GET(ApiConstants.API_PROVIDERS_PATHL)
+    @GET(ApiConstants.API_PROVIDERS_PATH)
     Call<ProvidersResponse> getProviders(@Query(SEConstants.KEY_COUNTRY_CODE) String countryCode,
                                          @Query(SEConstants.KEY_INCLUDE_FAKE_PROVIDERS) boolean includeFakeProviders,
                                          @Query(SEConstants.KEY_FROM_ID) String fromId);

--- a/saltedge-library/src/main/java/com/saltedge/sdk/network/SERequestManager.java
+++ b/saltedge-library/src/main/java/com/saltedge/sdk/network/SERequestManager.java
@@ -35,6 +35,8 @@ import com.saltedge.sdk.interfaces.FetchTransactionsResult;
 import com.saltedge.sdk.interfaces.TokenConnectionResult;
 import com.saltedge.sdk.utils.SEConstants;
 
+import java.util.Map;
+
 public class SERequestManager {
 
     private static SERequestManager instance;
@@ -61,6 +63,10 @@ public class SERequestManager {
      * */
     public void createToken(String providerCode, String[] scopes, String returnTo, String customerSecret, TokenConnectionResult callback) {
         new TokenConnector(callback).createToken(providerCode, scopes, returnTo, customerSecret);
+    }
+
+    public void createToken(Map<String, Object> dataMap, String customerSecret, TokenConnectionResult callback) {
+        new TokenConnector(callback).createToken(dataMap, customerSecret);
     }
 
     public void reconnectToken(String localeCode, String returnTo, String loginSecret, String customerSecret, TokenConnectionResult callback) {

--- a/saltedge-library/src/main/java/com/saltedge/sdk/utils/SEJsonTools.java
+++ b/saltedge-library/src/main/java/com/saltedge/sdk/utils/SEJsonTools.java
@@ -93,7 +93,8 @@ public class SEJsonTools {
     public static String getErrorMessage(ResponseBody error) {
         try {
             ApiError apiError = new Gson().fromJson(error.string(), ApiError.class);
-            return apiError.getErrorMessage();
+            String result = apiError.getErrorMessage();
+            return (result != null) ? result : SEConstants.REQUEST_ERROR;
         } catch (Exception e) {
             e.printStackTrace();
             return SEConstants.REQUEST_ERROR;


### PR DESCRIPTION
1) Updated gradle  
2) Added SERequestManager.createToken(Map<String, Object> dataMap, String customerSecret, TokenConnectionResult callback).
Now user can create request with custom params inside data object.